### PR TITLE
Fix(schema): Correct case for 'call' and 'set' properties

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -75,14 +75,14 @@
     "callStep": {
       "type": "object",
       "properties": {
-        "call": { "type": "string" }
+        "CALL": { "type": "string" }
       },
       "required": ["CALL"]
     },
     "setStep": {
       "type": "object",
       "properties": {
-        "set": { "type": "object" }
+        "SET": { "type": "object" }
       },
       "required": ["SET"]
     }


### PR DESCRIPTION
The `schema.json` file had `call` and `set` properties in lowercase, while the application code in `src/reqman4/scenario.py` expects them in uppercase (`CALL` and `SET`).

This commit updates the `schema.json` to use uppercase `CALL` and `SET` for consistency with the code, resolving the validation issue.